### PR TITLE
Custom Pseudo Character Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,4 @@ console.log(genPseudo.format(text));
 | `doExpand`    | `true`  | When `false`, will _not_ expand the input. Expanding characters is useful to ensure your codebase accounts for move verbose languages
 | `expandChars`    | ASCII upper and lower chars  | A string of characters that will be randomly selected to create an expansion of the input string.
 | `prependChars` | `"世界"` | When provided, these characters will be prepended to the output. This is helpful when you have certain characters that always seem to give your system trouble
+| `pseudoChars` | [Reference](https://github.com/AaronPresley/i18n-pseudo-js/blob/master/src/char-map.ts) | A hash map of the pseudo characters that will replace the ASCII characters. For default value, see the `pseudoCharacterMap` value in the `char-map.ts` file

--- a/__tests__/pseudo-format.test.ts
+++ b/__tests__/pseudo-format.test.ts
@@ -9,14 +9,12 @@ const pfOpts:Partial<PseudoFormatOptions> = {
 describe('PseudoFormat', () => {
     it('should pseudo basic text', () => {
         const value = `Hello, World!`;
-        const genPseudo = new PseudoFormat({
-            doExpand: false,
-        });
+        const genPseudo = new PseudoFormat({ doExpand: false });
         const output = genPseudo.format(value);
         
         expect(output).toEqual(`世界Ĥệḻḻỗ, 𝕎ỗřḻḋ!你好`);
-        
     });
+
     it('should pseudo translate with an argment', () => {
         const value = `Hi, { name }!`;
         const genPseudo = new PseudoFormat(pfOpts);
@@ -109,5 +107,15 @@ describe('PseudoFormat', () => {
         expect(() => {
             genPseudo.format('This is a { bad string');
         }).toThrow(`There was a problem parsing that string. Are you sure there's not an issue with the ICU Message Format? Here's the error I got:\nSyntaxError: Expected "," or "}" but "s" found.`);
+    });
+
+    it('should allow me to substitue my own pseudo characters', () => {
+        const genPseudo = new PseudoFormat({
+            ...pfOpts,
+            doExpand: false,
+            pseudoChars: { 'A': 'Z', 'a': 'z' },
+        });
+        const output = genPseudo.format('Aaron');
+        expect(output).toEqual('Zzron');
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-pseudo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "license": "MIT",
   "bin": {

--- a/src/pseudo-format.ts
+++ b/src/pseudo-format.ts
@@ -7,6 +7,7 @@ const DEFAULT_OPTIONS:PseudoFormatOptions = {
     doExpand: true,
     expandChars: expansionCharacters,
     prependChars: '世界',
+    pseudoChars: pseudoCharacterMap,
 }
 
 class PseudoFormat {
@@ -68,6 +69,7 @@ class PseudoFormat {
      * @returns A pseudolocalized string
      */
     private makePseudo = (input:string):string => {
+        const { pseudoChars } = this.options;
         let ignoreUntilChar:string = null;
         let output:string = '';
 
@@ -85,7 +87,7 @@ class PseudoFormat {
             // Append to our output
             output += !!ignoreUntilChar
                 ? thisChar
-                : pseudoCharacterMap[thisChar] || thisChar;
+                : pseudoChars[thisChar] || thisChar;
         }
         
         return output;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export interface PseudoFormatOptions {
   doExpand: boolean;
   expandChars: string;
   prependChars: string;
+  pseudoChars: Record<string, string>;
 }
 
 // The below is pulled from


### PR DESCRIPTION
Fixes #1

Allows the developer to pass their own pseudo character map instead of using the default.